### PR TITLE
Removed Radhika as Maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,6 @@ If you have a question about translations, raise an issue and we'll be happy to 
 
 # Acknowledgement
 
-96Boards pinout Maintainers: [radhikap18](https://github.com/radhikap18) and [ric96](https://github.com/ric96)
+96Boards pinout Maintainers: [ric96](https://github.com/ric96)
 
 Pinout.xyz Maintainers: [@Gadgetoid](https://github.com/Gadgetoid) and [@RogueM](https://github.com/RogueM)


### PR DESCRIPTION
While Radhika was one of the original contributors who ported this repo
to 96Boards, she will not longer be maintaining the 96Boards org repo.

Signed-off-by: Robert Wolff <robert.wolff@linaro.org>