### PR TITLE
uart-serial-mezzanine: stop declaring i2c pins

### DIFF
--- a/src/en/overlay/uart-serial-mezzanine.md
+++ b/src/en/overlay/uart-serial-mezzanine.md
@@ -22,14 +22,6 @@ ground:
   '39':
   '40':
 pin:
-  '15':
-    mode: i2c
-  '17':
-    mode: i2c
-  '19':
-    mode: i2c
-  '21':
-    mode: i2c
   '3':
     mode: uart
   '5':


### PR DESCRIPTION
UART Serial Mezzanine doesn't use I2C pins, so stop declaring them as
used.

Signed-off-by: Dmitry Baryshkov <dbaryshkov@gmail.com>